### PR TITLE
Reveresed minute and hour in how crons are parsed. 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ name := "akron"
 organization := "com.markatta"
 scalaVersion := "2.11.7"
 
-lazy val akkaVersion = "2.4.0-RC1"
+lazy val akkaVersion = "2.4.17"
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test"

--- a/src/main/scala/com/markatta/akron/ExpressionParser.scala
+++ b/src/main/scala/com/markatta/akron/ExpressionParser.scala
@@ -83,8 +83,8 @@ private [akron] class ExpressionParser extends RegexParsers {
     exactly.map { case Exactly(n) => Exactly(n % 7)}
 
 
-  def expression: Parser[CronExpression] = hour ~ minute ~ dayOfMonth ~ month ~ dayOfWeek ^^ {
-    case hour~minute~dayOfMonth~month~dayOfWeek => CronExpression(hour, minute, dayOfMonth, month, dayOfWeek)
+  def expression: Parser[CronExpression] = minute ~ hour ~ dayOfMonth ~ month ~ dayOfWeek ^^ {
+    case minute~hour~dayOfMonth~month~dayOfWeek => CronExpression(minute, hour, dayOfMonth, month, dayOfWeek)
   }
 
 

--- a/src/main/scala/com/markatta/akron/model.scala
+++ b/src/main/scala/com/markatta/akron/model.scala
@@ -75,8 +75,8 @@ object CronExpression {
 }
 
 case class CronExpression(
-   hour: HourExpression,
    minute: MinuteExpression,
+   hour: HourExpression,
    dayOfMonth: DayOfMonthExpression,
    month: MonthExpression,
    dayOfWeek: DayOfWeekExpression) {

--- a/src/test/scala/com/markatta/akron/ExpressionParserSpec.scala
+++ b/src/test/scala/com/markatta/akron/ExpressionParserSpec.scala
@@ -14,27 +14,27 @@ class ExpressionParserSpec extends BaseSpec {
     }
 
     "parse a simple hour minute expression" in {
-      CronExpression.parse("19 30 * * *") shouldEqual
-        Success(CronExpression(19, 30, *, *, *))
+      CronExpression.parse("30 19 * * *") shouldEqual
+        Success(CronExpression(30, 19, *, *, *))
     }
 
     "parse a simple expression with month and day of month" in {
-      CronExpression.parse("19 30 20 jan *") shouldEqual
-        Success(CronExpression(19, 30, 20, 1, *))
+      CronExpression.parse("30 19 20 jan *") shouldEqual
+        Success(CronExpression(30, 19, 20, 1, *))
     }
 
     "parse a simple expression with day of week" in {
-      CronExpression.parse("19 30 * jan mon") shouldEqual
-        Success(CronExpression(19, 30, *, 1, 1))
+      CronExpression.parse("30 19 * jan mon") shouldEqual
+        Success(CronExpression(30, 19, *, 1, 1))
     }
 
     "fail if both day of month and day of week is provided" in {
-      CronExpression.parse("19 30 20 jan mon") shouldBe a[Failure[_]]
+      CronExpression.parse("30 19 20 jan mon") shouldBe a[Failure[_]]
     }
 
     "parse a list of values" in {
-      CronExpression.parse("19,20 30,40 * jan,feb mon,tue") shouldBe
-        Success(CronExpression(many(19,20), many(30, 40), *, many(1,2), many(1, 2)))
+      CronExpression.parse("30,40 19,20 * jan,feb mon,tue") shouldBe
+        Success(CronExpression(many(30, 40), many(19,20), *, many(1,2), many(1, 2)))
     }
 
     "ignore case" in {
@@ -43,13 +43,13 @@ class ExpressionParserSpec extends BaseSpec {
     }
 
     "parse a range" in {
-      CronExpression.parse("15-20 20-30 12-15 * *") shouldBe
-        Success(CronExpression(15 to 20, 20 to 30, 12 to 15, *, *))
+      CronExpression.parse("20-30 15-20 12-15 * *") shouldBe
+        Success(CronExpression(20 to 30, 15 to 20, 12 to 15, *, *))
     }
 
     "parse a star-slash expression" in {
-      CronExpression.parse("*/20 */30 */2 * *") shouldBe
-        Success(CronExpression(* / 20, * / 30, * / 2, *, *))
+      CronExpression.parse("*/30 */20 */2 * *") shouldBe
+        Success(CronExpression(* / 30, * / 20, * / 2, *, *))
     }
 
   }

--- a/src/test/scala/com/markatta/akron/ModelSpec.scala
+++ b/src/test/scala/com/markatta/akron/ModelSpec.scala
@@ -76,7 +76,7 @@ class ModelSpec extends BaseSpec {
     "locate the next event from a given time 1" in {
       val from = LocalDateTime.of(2015, 1, 1, 14, 30)
 
-      val expression = CronExpression(20, 30, *, *, *)
+      val expression = CronExpression(30, 20, *, *, *)
 
       val result = expression.nextOccurrence(from)
 
@@ -90,7 +90,7 @@ class ModelSpec extends BaseSpec {
     "locate the next event from a given time 2" in {
       val from = LocalDateTime.of(2015, 1, 1, 14, 30)
 
-      val expression = CronExpression(* / 4, 0, *, *, *)
+      val expression = CronExpression(0, * / 4, *, *, *)
 
       val result = expression.nextOccurrence(from)
 
@@ -104,7 +104,7 @@ class ModelSpec extends BaseSpec {
     "locate the next event from a given time 3" in {
       val from = LocalDateTime.of(2015, 1, 1, 14, 30)
 
-      val expression = CronExpression(10, many(15, 25, 35), *, *, tue)
+      val expression = CronExpression(many(15, 25, 35), 10, *, *, tue)
 
       val result = expression.nextOccurrence(from)
 
@@ -117,7 +117,7 @@ class ModelSpec extends BaseSpec {
     "locate the next event from a given time 4" in {
       val from = LocalDateTime.of(2015, 1, 1, 20, 54)
 
-      val expression = CronExpression(*, * / 5, *, *, *)
+      val expression = CronExpression(* / 5, *, *, *, *)
 
       val result = expression.nextOccurrence(from)
 

--- a/src/test/scala/com/markatta/akron/TestApp.scala
+++ b/src/test/scala/com/markatta/akron/TestApp.scala
@@ -28,7 +28,7 @@ object TestApp extends App {
   val crontab = system.actorOf(CronTab.props, "crontab")
 
 
-  println("""Write cron expressions to schedule "[h] [m] [d] [M] [dow] text-msg-to-send" (or 'quit' to quit).""")
+  println("""Write cron expressions to schedule "[m] [h] [d] [M] [dow] text-msg-to-send" (or 'quit' to quit).""")
   val Pattern = """((?:\S+ ){5})(\S+)""".r
   Stream
     .continually(StdIn.readLine())


### PR DESCRIPTION
According to a few google searches, crons are typically rendered with minute first. For example. https://code.tutsplus.com/tutorials/scheduling-tasks-with-cron-jobs--net-8800
http://www.nncron.ru/help/EN/working/cron-format.htm

If you would rather not merge this in, I'll just use a fork in the apps I have using this. 

Solves https://github.com/johanandren/akron/issues/1
Also bumped versions of deps to most recent.