### PR TITLE
Logging fix to show the proper expression

### DIFF
--- a/src/main/scala/com/markatta/akron/model.scala
+++ b/src/main/scala/com/markatta/akron/model.scala
@@ -129,7 +129,7 @@ case class CronExpression(
   }
 
 
-  override def toString = s"$hour $minute $dayOfMonth $month $dayOfWeek"
+  override def toString = s"$minute $hour $dayOfMonth $month $dayOfWeek"
 
 }
 


### PR DESCRIPTION
Unfortunately I missed this logging statement. No functionality change, just confusing when looking at logs. 